### PR TITLE
Enhance support page with meeting finder modal

### DIFF
--- a/src/services/meetingFinderService.ts
+++ b/src/services/meetingFinderService.ts
@@ -1,0 +1,57 @@
+export interface Meeting {
+  id: string;
+  name: string;
+  type: string;
+  day: string;
+  time: string;
+  location: string;
+  virtual?: boolean;
+  link?: string;
+}
+
+class MeetingFinderService {
+  async searchMeetings(options: {
+    latitude?: number;
+    longitude?: number;
+    radius?: number;
+  } = {}): Promise<Meeting[]> {
+    // In a real app this would call an API with the given coordinates
+    await new Promise(resolve => setTimeout(resolve, 500));
+    return [
+      {
+        id: '1',
+        name: 'Downtown AA Meeting',
+        type: 'AA',
+        day: 'Mon',
+        time: '7:00 PM',
+        location: '123 Main St, Springfield',
+      },
+      {
+        id: '2',
+        name: 'Lunchtime Recovery',
+        type: 'NA',
+        day: 'Wed',
+        time: '12:00 PM',
+        location: '456 Oak Ave, Springfield',
+      },
+      {
+        id: '3',
+        name: 'Online Support Meeting',
+        type: 'SMART',
+        day: 'Fri',
+        time: '6:00 PM',
+        location: 'Virtual',
+        virtual: true,
+        link: 'https://example.com/meeting',
+      },
+    ];
+  }
+
+  getDirectionsUrl(meeting: Meeting): string {
+    const query = encodeURIComponent(meeting.location);
+    return `https://www.google.com/maps/dir/?api=1&destination=${query}`;
+  }
+}
+
+const meetingFinderService = new MeetingFinderService();
+export default meetingFinderService;

--- a/src/utils/supportResources.ts
+++ b/src/utils/supportResources.ts
@@ -1,0 +1,34 @@
+export const onlineSupportResources = [
+  {
+    name: 'In The Rooms',
+    description: 'Global recovery community',
+    url: 'https://www.intherooms.com'
+  },
+  {
+    name: 'SMART Recovery',
+    description: 'Science-based meetings',
+    url: 'https://smartrecovery.org'
+  },
+  {
+    name: 'AA Online Intergroup',
+    description: 'Virtual AA meetings',
+    url: 'https://aa-intergroup.org'
+  },
+  {
+    name: 'Sober Grid',
+    description: 'Sober social network',
+    url: 'https://www.sobergrid.com'
+  }
+];
+
+export const sponsorshipResources = {
+  findingSponsor: {
+    tips: [
+      'Attend local meetings regularly',
+      'Introduce yourself and share your goal',
+      'Look for someone with experience',
+      'Exchange contact information',
+      'Reach out and ask if they\'re available'
+    ]
+  }
+};


### PR DESCRIPTION
## Summary
- build a mock `meetingFinderService`
- add helpful support resource utilities
- overhaul `Support` page with new views and meeting finder modal

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f544dfcd0832dae0532317d555af4