### PR TITLE
Improve dark mode components

### DIFF
--- a/src/components/daily-checkin/MoodSection.tsx
+++ b/src/components/daily-checkin/MoodSection.tsx
@@ -1,6 +1,7 @@
 
 import React from 'react';
 import { Badge } from '@/components/ui/badge';
+import RangeSlider from './RangeSlider';
 
 interface MoodSectionProps {
   mood: number | null;
@@ -34,13 +35,12 @@ export const MoodSection: React.FC<MoodSectionProps> = ({ mood, onMoodChange }) 
         </div>
         
         <div className="relative">
-          <input
-            type="range"
-            min="1"
-            max="10"
+          <RangeSlider
+            min={1}
+            max={10}
             value={mood || 5}
             onChange={(e) => handleMoodChange(parseInt(e.target.value))}
-            className="w-full h-3 bg-blue-100 rounded-lg appearance-none cursor-pointer [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:h-5 [&::-webkit-slider-thumb]:w-5 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-blue-500 [&::-webkit-slider-thumb]:cursor-pointer [&::-webkit-slider-thumb]:border-2 [&::-webkit-slider-thumb]:border-white [&::-webkit-slider-thumb]:shadow-md [&::-moz-range-thumb]:h-5 [&::-moz-range-thumb]:w-5 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:bg-blue-500 [&::-moz-range-thumb]:cursor-pointer [&::-moz-range-thumb]:border-2 [&::-moz-range-thumb]:border-white [&::-moz-range-thumb]:shadow-md"
+            className="w-full"
             aria-label="Mood rating from 1 to 10"
           />
           <div className="flex justify-between text-xs text-gray-400 mt-1 px-1">

--- a/src/components/daily-checkin/RangeSlider.tsx
+++ b/src/components/daily-checkin/RangeSlider.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export interface RangeSliderProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+export const RangeSlider = React.forwardRef<HTMLInputElement, RangeSliderProps>(
+  ({ className = '', ...props }, ref) => (
+    <input type="range" ref={ref} className={className} {...props} />
+  )
+);
+
+RangeSlider.displayName = 'RangeSlider';
+
+export default RangeSlider;

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -8,9 +8,9 @@ const alertVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-background text-foreground",
+        default: "bg-white text-gray-950 dark:bg-gray-950 dark:text-gray-50 border-gray-200 dark:border-gray-800",
         destructive:
-          "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
+          "border-red-500/50 text-red-600 dark:text-red-400 dark:border-red-500/50 bg-red-50 dark:bg-red-900/10",
       },
     },
     defaultVariants: {

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,5 +1,4 @@
 import * as React from "react"
-
 import { cn } from "@/lib/utils"
 
 const Card = React.forwardRef<
@@ -9,7 +8,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-lg border bg-card text-card-foreground shadow-sm",
+      "rounded-lg border border-gray-200 bg-white text-gray-950 shadow-sm dark:border-gray-800 dark:bg-gray-950 dark:text-gray-50",
       className
     )}
     {...props}
@@ -36,7 +35,7 @@ const CardTitle = React.forwardRef<
   <h3
     ref={ref}
     className={cn(
-      "text-2xl font-semibold leading-none tracking-tight",
+      "text-2xl font-semibold leading-none tracking-tight text-gray-900 dark:text-gray-100",
       className
     )}
     {...props}
@@ -50,7 +49,7 @@ const CardDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <p
     ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
+    className={cn("text-sm text-gray-500 dark:text-gray-400", className)}
     {...props}
   />
 ))

--- a/src/index.css
+++ b/src/index.css
@@ -250,6 +250,17 @@
   .dark .slider-gradient-blue .bg-primary {
     background: linear-gradient(to right, #3b82f6, #1e40af) !important;
   }
+
+  /* Range slider styles */
+  input[type='range'] {
+    @apply w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer dark:bg-gray-700;
+  }
+  input[type='range']::-webkit-slider-thumb {
+    @apply appearance-none w-5 h-5 rounded-full bg-primary border-2 border-white shadow dark:border-gray-950;
+  }
+  input[type='range']::-moz-range-thumb {
+    @apply appearance-none w-5 h-5 rounded-full bg-primary border-2 border-white shadow dark:border-gray-950;
+  }
 }
 
 @keyframes gentle-pulse {


### PR DESCRIPTION
## Summary
- enhance Card and Alert components for better dark mode support
- style range sliders and add new RangeSlider component
- use RangeSlider in MoodSection

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685412083068832d814f95e92537418c