### PR TITLE
Fix dark mode readability and add home components

### DIFF
--- a/src/components/daily-checkin/AssessmentsSection.tsx
+++ b/src/components/daily-checkin/AssessmentsSection.tsx
@@ -57,7 +57,7 @@ export const AssessmentsSection: React.FC<AssessmentsSectionProps> = ({
               </TooltipContent>
             </Tooltip>
           </h3>
-          <p className="text-gray-600 mb-4">
+          <p className="text-gray-600 dark:text-gray-300 mb-4">
             Answer these questions to help track your mental well-being over time.
           </p>
         </div>
@@ -70,7 +70,7 @@ export const AssessmentsSection: React.FC<AssessmentsSectionProps> = ({
             
             <div className="space-y-3">
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-2">
                   Little interest or pleasure in doing things? {isFieldRequired(phq2Q1) && <span className="text-red-500">*</span>}
                   <Tooltip>
                     <TooltipTrigger asChild>
@@ -90,14 +90,14 @@ export const AssessmentsSection: React.FC<AssessmentsSectionProps> = ({
                         onChange={() => onPhq2Q1Change(option.value)}
                         className="h-4 w-4 text-blue-600 focus:ring-blue-500"
                       />
-                      <span className="text-sm text-gray-700">{option.label}</span>
+                      <span className="text-sm text-gray-700 dark:text-gray-200">{option.label}</span>
                     </label>
                   ))}
                 </div>
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-2">
                   Feeling down, depressed, or hopeless? {isFieldRequired(phq2Q2) && <span className="text-red-500">*</span>}
                   <Tooltip>
                     <TooltipTrigger asChild>
@@ -117,7 +117,7 @@ export const AssessmentsSection: React.FC<AssessmentsSectionProps> = ({
                         onChange={() => onPhq2Q2Change(option.value)}
                         className="h-4 w-4 text-blue-600 focus:ring-blue-500"
                       />
-                      <span className="text-sm text-gray-700">{option.label}</span>
+                      <span className="text-sm text-gray-700 dark:text-gray-200">{option.label}</span>
                     </label>
                   ))}
                 </div>
@@ -132,7 +132,7 @@ export const AssessmentsSection: React.FC<AssessmentsSectionProps> = ({
             
             <div className="space-y-3">
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-2">
                   Feeling nervous, anxious, or on edge? {isFieldRequired(gad2Q1) && <span className="text-red-500">*</span>}
                   <Tooltip>
                     <TooltipTrigger asChild>
@@ -152,14 +152,14 @@ export const AssessmentsSection: React.FC<AssessmentsSectionProps> = ({
                         onChange={() => onGad2Q1Change(option.value)}
                         className="h-4 w-4 text-green-600 focus:ring-green-500"
                       />
-                      <span className="text-sm text-gray-700">{option.label}</span>
+                      <span className="text-sm text-gray-700 dark:text-gray-200">{option.label}</span>
                     </label>
                   ))}
                 </div>
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-2">
                   Not being able to stop or control worrying? {isFieldRequired(gad2Q2) && <span className="text-red-500">*</span>}
                   <Tooltip>
                     <TooltipTrigger asChild>
@@ -179,7 +179,7 @@ export const AssessmentsSection: React.FC<AssessmentsSectionProps> = ({
                         onChange={() => onGad2Q2Change(option.value)}
                         className="h-4 w-4 text-green-600 focus:ring-green-500"
                       />
-                      <span className="text-sm text-gray-700">{option.label}</span>
+                      <span className="text-sm text-gray-700 dark:text-gray-200">{option.label}</span>
                     </label>
                   ))}
                 </div>
@@ -188,7 +188,7 @@ export const AssessmentsSection: React.FC<AssessmentsSectionProps> = ({
           </div>
         </div>
 
-        <div className="text-xs text-gray-500">
+        <div className="text-xs text-gray-500 dark:text-gray-400">
           <span className="text-red-500">*</span> All questions are required to complete this section
         </div>
       </div>

--- a/src/components/daily-checkin/CheckInCompleted.tsx
+++ b/src/components/daily-checkin/CheckInCompleted.tsx
@@ -54,28 +54,28 @@ export const CheckInCompleted: React.FC<CheckInCompletedProps> = ({
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="grid grid-cols-2 gap-4">
-              <div className="bg-white p-3 rounded-lg">
+              <div className="bg-white dark:bg-gray-800 p-3 rounded-lg">
                 <div className="flex items-center justify-between">
-                  <span className="text-gray-600 text-sm">Mood</span>
+                  <span className="text-gray-600 dark:text-gray-300 text-sm">Mood</span>
                   <Heart className="w-4 h-4 text-pink-500" />
                 </div>
                 <div className="mt-1">
                   <span className="text-2xl font-bold">{responses.mood || 0}</span>
-                  <span className="text-gray-500">/10</span>
+                  <span className="text-gray-500 dark:text-gray-400">/10</span>
                 </div>
                 <p className={`text-xs mt-1 ${getScoreSummary(responses.mood || 0).color}`}>
                   {getScoreSummary(responses.mood || 0).label}
                 </p>
               </div>
               
-              <div className="bg-white p-3 rounded-lg">
+              <div className="bg-white dark:bg-gray-800 p-3 rounded-lg">
                 <div className="flex items-center justify-between">
-                  <span className="text-gray-600 text-sm">Energy</span>
+                  <span className="text-gray-600 dark:text-gray-300 text-sm">Energy</span>
                   <Battery className="w-4 h-4 text-blue-500" />
                 </div>
                 <div className="mt-1">
                   <span className="text-2xl font-bold">{responses.energy || 0}</span>
-                  <span className="text-gray-500">/10</span>
+                  <span className="text-gray-500 dark:text-gray-400">/10</span>
                 </div>
                 <p className={`text-xs mt-1 ${getScoreSummary(responses.energy || 0).color}`}>
                   {getScoreSummary(responses.energy || 0).label}
@@ -84,25 +84,25 @@ export const CheckInCompleted: React.FC<CheckInCompletedProps> = ({
             </div>
 
             <div className="grid grid-cols-2 gap-4">
-              <div className="bg-white p-3 rounded-lg">
+              <div className="bg-white dark:bg-gray-800 p-3 rounded-lg">
                 <div className="flex items-center justify-between">
-                  <span className="text-gray-600 text-sm">Hope Level</span>
+                  <span className="text-gray-600 dark:text-gray-300 text-sm">Hope Level</span>
                   <Trophy className="w-4 h-4 text-yellow-500" />
                 </div>
                 <div className="mt-1">
                   <span className="text-2xl font-bold">{responses.hope || 0}</span>
-                  <span className="text-gray-500">/10</span>
+                  <span className="text-gray-500 dark:text-gray-400">/10</span>
                 </div>
               </div>
               
-              <div className="bg-white p-3 rounded-lg">
+              <div className="bg-white dark:bg-gray-800 p-3 rounded-lg">
                 <div className="flex items-center justify-between">
-                  <span className="text-gray-600 text-sm">Sobriety Confidence</span>
+                  <span className="text-gray-600 dark:text-gray-300 text-sm">Sobriety Confidence</span>
                   <Brain className="w-4 h-4 text-purple-500" />
                 </div>
                 <div className="mt-1">
                   <span className="text-2xl font-bold">{responses.sobriety_confidence || 0}</span>
-                  <span className="text-gray-500">/10</span>
+                  <span className="text-gray-500 dark:text-gray-400">/10</span>
                 </div>
               </div>
             </div>

--- a/src/components/daily-checkin/CheckInCompletion.tsx
+++ b/src/components/daily-checkin/CheckInCompletion.tsx
@@ -67,7 +67,7 @@ export const CheckInCompletion: React.FC<CheckInCompletionProps> = ({
       </Card>
 
       {/* Auto-save indicator */}
-      <div className="text-center text-xs text-gray-500">
+      <div className="text-center text-xs text-gray-500 dark:text-gray-400">
         {isSaving ? 'Saving your responses...' : 'Your responses are automatically saved as you go'}
       </div>
     </>

--- a/src/components/daily-checkin/CheckInHeader.tsx
+++ b/src/components/daily-checkin/CheckInHeader.tsx
@@ -26,7 +26,7 @@ export const CheckInHeader: React.FC<CheckInHeaderProps> = ({
         </Button>
         
         {isSaving && (
-          <div className="flex items-center text-sm text-gray-500">
+          <div className="flex items-center text-sm text-gray-500 dark:text-gray-400">
             <Save className="w-4 h-4 mr-1 animate-pulse" />
             Saving...
           </div>
@@ -36,8 +36,8 @@ export const CheckInHeader: React.FC<CheckInHeaderProps> = ({
       {/* Header */}
       <div className="text-center space-y-2">
         <h1 className="text-2xl font-bold text-[#1E3A8A]">Daily Check-In</h1>
-        <p className="text-gray-600">Take a moment to reflect on your day</p>
-        <p className="text-sm text-gray-500">
+        <p className="text-gray-600 dark:text-gray-300">Take a moment to reflect on your day</p>
+        <p className="text-sm text-gray-500 dark:text-gray-400">
           {new Date().toLocaleDateString('en-US', { 
             weekday: 'long', 
             year: 'numeric', 

--- a/src/components/daily-checkin/CheckInProgress.tsx
+++ b/src/components/daily-checkin/CheckInProgress.tsx
@@ -23,17 +23,17 @@ export const CheckInProgress: React.FC<CheckInProgressProps> = ({
           <div className="space-y-3">
             <div className="flex justify-between items-center">
               <span className="text-sm font-medium">Progress</span>
-              <span className="text-sm text-gray-500">{completedSections.size}/3 sections</span>
+              <span className="text-sm text-gray-500 dark:text-gray-400">{completedSections.size}/3 sections</span>
             </div>
             <Progress value={progressPercentage} className="h-2" />
             <div className="grid grid-cols-3 gap-2 text-xs">
-              <div className={`text-center p-2 rounded ${completedSections.has('mood') ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-500'}`}>
+              <div className={`text-center p-2 rounded ${completedSections.has('mood') ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-500 dark:text-gray-400'}`}>
                 {completedSections.has('mood') ? '✓' : '○'} Mood
               </div>
-              <div className={`text-center p-2 rounded ${completedSections.has('wellness') ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-500'}`}>
+              <div className={`text-center p-2 rounded ${completedSections.has('wellness') ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-500 dark:text-gray-400'}`}>
                 {completedSections.has('wellness') ? '✓' : '○'} Wellness
               </div>
-              <div className={`text-center p-2 rounded ${completedSections.has('assessments') ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-500'}`}>
+              <div className={`text-center p-2 rounded ${completedSections.has('assessments') ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-500 dark:text-gray-400'}`}>
                 {completedSections.has('assessments') ? '✓' : '○'} Assessments
               </div>
             </div>

--- a/src/components/daily-checkin/CheckInSuccess.tsx
+++ b/src/components/daily-checkin/CheckInSuccess.tsx
@@ -15,7 +15,7 @@ export const CheckInSuccess: React.FC = () => {
           <p className="text-green-700 text-lg">
             Your check-in has been saved. Keep up the amazing work on your recovery journey!
           </p>
-          <div className="flex items-center justify-center space-x-2 text-gray-600">
+          <div className="flex items-center justify-center space-x-2 text-gray-600 dark:text-gray-300">
             <Loader2 className="w-4 h-4 animate-spin" />
             <span>Redirecting to dashboard...</span>
           </div>

--- a/src/components/daily-checkin/MoodSection.tsx
+++ b/src/components/daily-checkin/MoodSection.tsx
@@ -25,11 +25,11 @@ export const MoodSection: React.FC<MoodSectionProps> = ({ mood, onMoodChange }) 
     <div className="space-y-4">
       <div>
         <h3 className="text-xl font-semibold mb-2">How are you feeling today?</h3>
-        <p className="text-gray-600 mb-4">Rate your overall mood on a scale from 1 to 10.</p>
+        <p className="text-gray-600 dark:text-gray-300 mb-4">Rate your overall mood on a scale from 1 to 10.</p>
       </div>
       
       <div className="space-y-4">
-        <div className="flex items-center justify-between text-sm text-gray-500 px-1">
+        <div className="flex items-center justify-between text-sm text-gray-500 dark:text-gray-400 px-1">
           <span>Not Great (1)</span>
           <span>Great! (10)</span>
         </div>

--- a/src/components/home/CheckInStatus.tsx
+++ b/src/components/home/CheckInStatus.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { CheckCircle, Heart } from 'lucide-react';
+
+interface CheckInStatusProps {
+  checkedIn: boolean;
+}
+
+export const CheckInStatus: React.FC<CheckInStatusProps> = ({ checkedIn }) => {
+  return (
+    <Card className="bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-600">
+      <CardContent className="p-4 text-center space-y-2">
+        {checkedIn ? (
+          <>
+            <CheckCircle className="w-6 h-6 text-emerald-600 dark:text-emerald-400 mx-auto" />
+            <p className="text-gray-600 dark:text-gray-300">You've checked in for today</p>
+          </>
+        ) : (
+          <>
+            <p className="text-gray-600 dark:text-gray-300">You haven't checked in yet</p>
+            <Button asChild>
+              <Link to="/checkin">
+                <Heart className="w-4 h-4 mr-2" />
+                Start Check-In
+              </Link>
+            </Button>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default CheckInStatus;

--- a/src/components/home/QuickActions.tsx
+++ b/src/components/home/QuickActions.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
+import { CalendarDays, Heart } from 'lucide-react';
+
+export const QuickActions: React.FC = () => {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      <Button
+        variant="outline"
+        className="h-16 btn-outline-navy focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+        asChild
+      >
+        <Link to="/calendar" aria-label="View recovery calendar and check-in history">
+          <CalendarDays className="mr-2 h-5 w-5" />
+          View Calendar
+        </Link>
+      </Button>
+      <Button
+        variant="outline"
+        className="h-16 btn-outline-emerald focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2"
+        asChild
+      >
+        <Link to="/checkin" aria-label="Complete detailed daily check-in assessment">
+          <Heart className="mr-2 h-5 w-5" />
+          Full Check-in
+        </Link>
+      </Button>
+    </div>
+  );
+};
+
+export default QuickActions;

--- a/src/components/home/RecoveryFocus.tsx
+++ b/src/components/home/RecoveryFocus.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { UnifiedRecoveryContent } from '@/components/daily/UnifiedRecoveryContent';
+
+export const RecoveryFocus: React.FC = () => {
+  return <UnifiedRecoveryContent />;
+};
+
+export default RecoveryFocus;

--- a/src/components/home/RecoveryGoals.tsx
+++ b/src/components/home/RecoveryGoals.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Progress } from '@/components/ui/progress';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Target, Plus } from 'lucide-react';
+
+export const RecoveryGoals: React.FC = () => {
+  const mockGoals = [
+    { id: 1, title: 'Daily Check-ins', progress: 70, category: 'wellness', priority: 'high' },
+    { id: 2, title: 'Meditation Practice', progress: 40, category: 'mindfulness', priority: 'medium' },
+    { id: 3, title: 'Exercise 3x Week', progress: 60, category: 'health', priority: 'high' }
+  ];
+
+  return (
+    <Card className="animate-slide-up hover-lift">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-gray-900 dark:text-gray-100">
+          <Target className="h-5 w-5 text-purple-600 dark:text-purple-400" />
+          Recovery Goals
+          <Badge variant="outline" className="ml-auto dark:border-gray-600 dark:text-gray-300">
+            {mockGoals.length} Active
+          </Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          {mockGoals.map((goal, index) => (
+            <div key={goal.id} className="space-y-2 animate-fade-in" style={{ animationDelay: `${index * 100}ms` }}>
+              <div className="flex items-center justify-between">
+                <div className="flex-1">
+                  <h4 className="font-medium text-sm text-gray-900 dark:text-gray-100">{goal.title}</h4>
+                  <p className="text-xs text-gray-600 dark:text-gray-300 capitalize">
+                    {goal.category} • {goal.priority} priority
+                  </p>
+                </div>
+                <Badge variant="outline" className="text-xs dark:border-gray-600 dark:text-gray-300">
+                  {goal.progress}%
+                </Badge>
+              </div>
+              <div className="relative">
+                <Progress value={goal.progress} className="h-2 bg-gray-200 dark:bg-gray-700" />
+              </div>
+            </div>
+          ))}
+
+          <Button variant="outline" size="sm" className="w-full mt-4 hover:scale-105 transition-transform dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800">
+            <Plus className="h-4 w-4 mr-2" />
+            Add New Goal
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default RecoveryGoals;

--- a/src/components/home/WelcomeHeader.tsx
+++ b/src/components/home/WelcomeHeader.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+interface WelcomeHeaderProps {
+  name?: string;
+  streak: number;
+  checkIns: number;
+}
+
+export const WelcomeHeader: React.FC<WelcomeHeaderProps> = ({ name, streak, checkIns }) => {
+  const displayName = name || 'Friend';
+  return (
+    <div className="text-center space-y-1">
+      <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Welcome back, {displayName}!</h1>
+      <p className="text-gray-600 dark:text-gray-300">
+        {streak} day streak • {checkIns} check-ins
+      </p>
+    </div>
+  );
+};
+
+export default WelcomeHeader;

--- a/src/index.css
+++ b/src/index.css
@@ -85,24 +85,6 @@
   }
 }
 
-/* Dark mode text fixes */
-.dark input::placeholder {
-  color: #9ca3af !important;
-}
-
-.dark .text-gray-600 {
-  color: #d1d5db !important;
-}
-
-.dark .bg-gray-50 {
-  background-color: #1f2937 !important;
-}
-
-.dark .bg-white {
-  background-color: #111827 !important;
-  color: #f3f4f6 !important;
-}
-
 @layer components {
   /* Improved button styling for better visibility */
   .btn-primary {
@@ -254,6 +236,12 @@
   /* Range slider styles */
   input[type='range'] {
     @apply w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer dark:bg-gray-700;
+  }
+  input[type='range']::-webkit-slider-runnable-track {
+    @apply h-2 rounded-lg bg-gray-200 dark:bg-gray-600;
+  }
+  input[type='range']::-moz-range-track {
+    @apply h-2 rounded-lg bg-gray-200 dark:bg-gray-600;
   }
   input[type='range']::-webkit-slider-thumb {
     @apply appearance-none w-5 h-5 rounded-full bg-primary border-2 border-white shadow dark:border-gray-950;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -5,7 +5,12 @@ import { useDashboardData } from '@/hooks/useDashboardData';
 import { useDashboardKeyboardShortcuts } from '@/hooks/useDashboardKeyboardShortcuts';
 import { useDashboardSessionManager } from '@/hooks/useDashboardSessionManager';
 import Layout from '@/components/Layout';
-import { DashboardContent } from '@/components/dashboard/DashboardContent';
+import WelcomeHeader from '@/components/home/WelcomeHeader';
+import CheckInStatus from '@/components/home/CheckInStatus';
+import RecoveryFocus from '@/components/home/RecoveryFocus';
+import QuickActions from '@/components/home/QuickActions';
+import RecoveryGoals from '@/components/home/RecoveryGoals';
+import { useDailyCheckIn } from '@/hooks/useDailyCheckIn';
 import SessionWarningDialog from '@/components/security/SessionWarningDialog';
 import { toast } from 'sonner';
 
@@ -34,6 +39,8 @@ const Index = () => {
     refreshStats();
     toast.success('Check-in completed!');
   };
+
+  const { existingCheckin } = useDailyCheckIn();
 
   // Show error state if there's a critical error
   if (error && !loading) {
@@ -65,18 +72,22 @@ const Index = () => {
 
   return (
     <>
-      <Layout 
-        activeTab={activeTab} 
+      <Layout
+        activeTab={activeTab}
         onTabChange={setActiveTab}
         onProfileClick={() => setShowProfile(!showProfile)}
       >
-        <DashboardContent
-          user={user}
-          profile={profile}
-          stats={stats}
-          loading={loading}
-          onCheckInComplete={handleCheckInComplete}
-        />
+        <div className="p-4 space-y-6 max-w-4xl mx-auto">
+          <WelcomeHeader
+            name={profile?.full_name || user?.email?.split('@')[0]}
+            streak={stats.streak}
+            checkIns={stats.checkIns}
+          />
+          <CheckInStatus checkedIn={!!existingCheckin} />
+          <RecoveryFocus />
+          <QuickActions />
+          <RecoveryGoals />
+        </div>
       </Layout>
 
       {/* Session Warning Dialog */}


### PR DESCRIPTION
## Summary
- implement dark mode text colors in check-in components
- add range slider track styling and remove overrides in CSS
- add home screen components and integrate into Index page

## Testing
- `npm run lint`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68546591ef90832dabff7daed5913e61