### PR TITLE
Update CalendarHeader design

### DIFF
--- a/src/components/calendar/CalendarHeader.tsx
+++ b/src/components/calendar/CalendarHeader.tsx
@@ -1,4 +1,3 @@
-
 import React from 'react';
 import { Button } from '@/components/ui/button';
 import {
@@ -7,12 +6,13 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { 
-  Calendar as CalendarIcon, 
-  Download, 
-  FileText, 
+import {
+  Calendar as CalendarIcon,
+  Download,
+  FileText,
   FileJson,
-  Filter
+  Filter,
+  Sparkles,
 } from 'lucide-react';
 
 interface CalendarHeaderProps {
@@ -27,36 +27,55 @@ const CalendarHeader: React.FC<CalendarHeaderProps> = ({
   onExport,
 }) => {
   return (
-    <div className="flex justify-between items-center mb-6">
-      <div className="flex items-center gap-2">
-        <CalendarIcon className="h-6 w-6 text-primary" />
-        <h1 className="text-2xl font-bold">Enhanced Mood Calendar</h1>
+    <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
+      <div className="flex items-center gap-3">
+        <div className="p-2 bg-gradient-to-br from-blue-500 to-emerald-500 rounded-lg">
+          <CalendarIcon className="h-6 w-6 text-white" />
+        </div>
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 flex items-center gap-2">
+            Recovery Calendar
+            <Sparkles className="h-5 w-5 text-yellow-500" />
+          </h1>
+          <p className="text-sm text-gray-600 dark:text-gray-400">Track your progress, celebrate your journey</p>
+        </div>
       </div>
-      
+
       <div className="flex items-center gap-2">
-        <Button 
-          onClick={onToggleFilters} 
-          variant="outline" 
+        <Button
+          onClick={onToggleFilters}
+          variant="outline"
           size="sm"
+          className="hover:bg-blue-50 dark:hover:bg-blue-900/20"
         >
           <Filter className="h-4 w-4 mr-2" />
           {showFilters ? 'Hide Filters' : 'Show Filters'}
         </Button>
-        
+
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <Button variant="outline" size="sm">
+            <Button
+              variant="outline"
+              size="sm"
+              className="hover:bg-emerald-50 dark:hover:bg-emerald-900/20"
+            >
               <Download className="h-4 w-4 mr-2" />
-              Export
+              Export Progress
             </Button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent className="bg-white border shadow-lg">
-            <DropdownMenuItem onClick={() => onExport('csv')}>
-              <FileText className="h-4 w-4 mr-2" />
+          <DropdownMenuContent className="bg-white dark:bg-gray-800 border shadow-lg">
+            <DropdownMenuItem
+              onClick={() => onExport('csv')}
+              className="hover:bg-gray-100 dark:hover:bg-gray-700"
+            >
+              <FileText className="h-4 w-4 mr-2 text-blue-600 dark:text-blue-400" />
               Export as CSV
             </DropdownMenuItem>
-            <DropdownMenuItem onClick={() => onExport('json')}>
-              <FileJson className="h-4 w-4 mr-2" />
+            <DropdownMenuItem
+              onClick={() => onExport('json')}
+              className="hover:bg-gray-100 dark:hover:bg-gray-700"
+            >
+              <FileJson className="h-4 w-4 mr-2 text-purple-600 dark:text-purple-400" />
               Export as JSON
             </DropdownMenuItem>
           </DropdownMenuContent>


### PR DESCRIPTION
## Summary
- refresh calendar header with a recovery-focused design

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6855eaaca640832dae9ba2406c6ee690