### PR TITLE
Add crisis response and accountability features

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import Support from '@/pages/Support';
 import CrisisToolkit from '@/pages/CrisisToolkit';
 import Settings from '@/pages/Settings';
 import Login from '@/pages/Login';
+import ManageTriggers from '@/pages/ManageTriggers';
 import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
 
 const queryClient = new QueryClient();
@@ -43,6 +44,11 @@ function App() {
             <Route path="/support" element={
               <ProtectedRoute>
                 <Support />
+              </ProtectedRoute>
+            } />
+            <Route path="/triggers/manage" element={
+              <ProtectedRoute>
+                <ManageTriggers />
               </ProtectedRoute>
             } />
             <Route path="/crisis-toolkit" element={

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -39,14 +39,37 @@ export function AuthProvider({ children }: AuthProviderProps) {
     return { error };
   };
 
+  const defaultTriggers = [
+    { name: 'Stress', category: 'emotional', intensity: 5, coping_strategies: ['Deep breathing'] },
+    { name: 'Social gatherings', category: 'social', intensity: 6, coping_strategies: ['Call sponsor'] },
+    { name: 'Bars or clubs', category: 'environmental', intensity: 7, coping_strategies: ['Leave immediately'] }
+  ];
+
   const signUp = async (email: string, password: string) => {
-    const { error } = await supabase.auth.signUp({
+    const { data, error } = await supabase.auth.signUp({
       email,
       password,
       options: {
         emailRedirectTo: `${window.location.origin}/`
       }
     });
+
+    if (!error && data.user) {
+      try {
+        await supabase.from('user_triggers').insert(
+          defaultTriggers.map((t) => ({
+            user_id: data.user?.id,
+            name: t.name,
+            category: t.category,
+            intensity: t.intensity,
+            coping_strategies: t.coping_strategies
+          }))
+        );
+      } catch (err) {
+        console.error('Error pre-populating triggers:', err);
+      }
+    }
+
     return { error };
   };
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,9 +1,15 @@
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import Index from './Index';
+import DailyAccountability from '@/components/accountability/DailyAccountability';
+import { requestNotificationPermission } from '@/services/mockPushService';
 
 // Simple wrapper to maintain compatibility
 const Home: React.FC = () => {
+  useEffect(() => {
+    requestNotificationPermission();
+  }, []);
+
   return <Index />;
 };
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -10,6 +10,7 @@ import CheckInStatus from '@/components/home/CheckInStatus';
 import RecoveryFocus from '@/components/home/RecoveryFocus';
 import QuickActions from '@/components/home/QuickActions';
 import RecoveryGoals from '@/components/home/RecoveryGoals';
+import DailyAccountability from '@/components/accountability/DailyAccountability';
 import { useDailyCheckIn } from '@/hooks/useDailyCheckIn';
 import SessionWarningDialog from '@/components/security/SessionWarningDialog';
 import { toast } from 'sonner';
@@ -86,6 +87,7 @@ const Index = () => {
           <CheckInStatus checkedIn={!!existingCheckin} />
           <RecoveryFocus />
           <QuickActions />
+          <DailyAccountability />
           <RecoveryGoals />
         </div>
       </Layout>

--- a/src/pages/ManageTriggers.tsx
+++ b/src/pages/ManageTriggers.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import Layout from '@/components/Layout';
+import TriggerManagementToolkit from '@/components/triggers/TriggerManagementToolkit';
+
+const ManageTriggers: React.FC = () => {
+  return (
+    <Layout activeTab="support" onTabChange={() => {}}>
+      <div className="p-4 max-w-4xl mx-auto">
+        <TriggerManagementToolkit />
+      </div>
+    </Layout>
+  );
+};
+
+export default ManageTriggers;

--- a/src/pages/Support.tsx
+++ b/src/pages/Support.tsx
@@ -19,6 +19,8 @@ const SupporterDashboard = lazy(() => import('@/components/supporter/SupporterDa
 
 import meetingFinderService from '@/services/meetingFinderService';
 import { onlineSupportResources, sponsorshipResources } from '@/utils/supportResources';
+import CrisisResponseSystem from '@/components/crisis/CrisisResponseSystem';
+import TriggerManagementToolkit from '@/components/triggers/TriggerManagementToolkit';
 
 const Support = () => {
   const [activeView, setActiveView] = useState<'main' | 'analytics' | 'network' | 'settings' | 'supporter'>('main');
@@ -116,6 +118,10 @@ const Support = () => {
 
   const handleViewSettings = () => {
     setActiveView('settings');
+  };
+
+  const handleViewTriggers = () => {
+    navigate('/triggers/manage');
   };
 
   const handleViewSupporter = () => {
@@ -246,6 +252,8 @@ const Support = () => {
           </CardContent>
         </Card>
 
+        <CrisisResponseSystem />
+
         <Card className="border-red-200 bg-red-50">
           <CardHeader>
             <CardTitle className="text-red-700 flex items-center gap-2">
@@ -319,6 +327,24 @@ const Support = () => {
             >
               <Settings className="w-4 h-4 mr-2" />
               Manage Professional Contacts
+            </Button>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <AlertTriangle className="w-5 h-5" />
+              Trigger Management
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <p className="text-sm text-gray-600">
+              Track and handle common relapse triggers
+            </p>
+            <Button onClick={handleViewTriggers} className="w-full" variant="outline">
+              <AlertTriangle className="w-4 h-4 mr-2" />
+              Manage Triggers
             </Button>
           </CardContent>
         </Card>


### PR DESCRIPTION
## Summary
- insert CrisisResponseSystem on the Support page
- add trigger management card with link to new ManageTriggers page
- create dedicated ManageTriggers page
- pre-populate default triggers on sign up
- show DailyAccountability on the dashboard and request notification permission
- route `/triggers/manage` to ManageTriggers

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685751b299d8832da37c0b3c3b7b1d69