### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI/CD Pipeline
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ccbuildalot23/serenity-sober-pathways-guide/security/code-scanning/15](https://github.com/ccbuildalot23/serenity-sober-pathways-guide/security/code-scanning/15)

To fix the problem, add a `permissions` block at the top level of the workflow file (just after the `name` and before `on`). This will apply the least privilege principle to all jobs in the workflow, restricting the `GITHUB_TOKEN` to only have read access to repository contents. This is the recommended minimal permission for most CI jobs that do not need to write to the repository or interact with issues, PRs, etc. No other changes are needed, as none of the jobs require broader permissions.

**Steps:**
- Insert the following block after the `name` field and before the `on` field in `.github/workflows/ci.yml`:
  ```yaml
  permissions:
    contents: read
  ```
- No new imports, methods, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
